### PR TITLE
Gi visuell feedback på elementer som er disabled

### DIFF
--- a/dist/kringkaster.html
+++ b/dist/kringkaster.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Gramo - Component based UI kit</title>
+
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="shortcut icon" href="img/favicon.png">
+  <link rel="apple-touch-icon" sizes="57x57" href="img/apple-touch-icon.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="img/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="img/apple-touch-icon-114x114.png">
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,600,700' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="style.css">
+
+</head>
+<body>
+  <div class="site-wrapper">
+    <!--Sidebar example-->
+    <div class="sidebar">
+      <section class="sidebar__content">
+        <header class="sidebar__header">
+          <h1 class="sidebar__header__title"><i class="icon--logo-echo"></i></h1>
+        </header>
+        <nav class="sidebar__nav">
+          <ul class="vertical__nav">
+            <li class="vertical__nav__item vertical__nav__item--isExpanded"><a href="#">Innlesning</a>
+              <ul class="vertical__nav vertical__nav--sub">
+                <li class="vertical__nav__item vertical__nav--sub__item"><a href="#">Innleste filer</a></li>
+                <li class="vertical__nav__item vertical__nav--sub__item vertical__nav--sub__item--active"><a href="#">Avvik kontroll</a></li>
+                <li class="vertical__nav__item vertical__nav--sub__item"><a href="#">Program admin</a></li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+        <aside class="user">
+          <img src="img/audun-temp.jpg" class="user__avatar">
+          <span class="user__name">Audun Haggernes</span>
+          <span class="user__logout"><a href="#">Logg ut</a></span>
+        </aside>
+      </section>
+    </div>
+    <!--End Sidebar example-->
+    <main>
+      <!--Site-header example-->
+      <header class="site-header">
+        <section class="container container--hd">
+          <!-- <h1 class="site-header__title"><img src="img/gramo-logo.png" alt="gramo logo"></h1>
+          <p class="site-header__description">Component based UI kit</p> -->
+          <nav>
+            <div class="toggle-sidebar">
+              <a href="#">
+                <span></span>
+                <span></span>
+                <span></span>
+              </a>
+            </div>
+            <ul class="breadcrumbs">
+              <li class="breadcrumbs__item breadcrumbs__item--home"><a href="#"><i class="icon--home"></i></a></li>
+              <li class="breadcrumbs__item"><a href="#">Innlesning</a></li>
+              <li class="breadcrumbs__item"><a href="#">Innleste filer</a></li>
+              <li class="breadcrumbs__item"><a href="#">NRK rapport</a></li>
+            </ul>
+          </nav>
+        </section>
+      </header>
+      <!--End Site-header example-->
+      <div class="flash-message">
+        <p>Flashmelding at noe ble gjort</p> <button class="btn btn--medium btn--inline btn--outline">OK</button>
+      </div>
+
+      <!--Content-header example-->
+      <section class="container container--hd">
+        <header class="content-header">
+          <div class="content-header__above">
+            <h2 class="content-header__title">Kringkaster <span class="badge badge--danger">NRK</span></h2>
+            <div class="content-header__action">
+              <a href="#" class="btn btn--info btn--medium">Last ned rapport</a>
+            </div>
+          </div>
+          <div class="content-header__below">
+            <span class="content-header__meta">
+              Første avvik: <date>02.11.15</date>
+            </span>
+            <span class="content-header__meta">
+              Siste avvik: <date>08.11.15</date>
+            </span>
+            <div class="content-header__action btn-group">
+              <button class="btn btn--info btn--small">Kanal <i class="icon--breadcrumbs-arrow"></i>Dato</button>
+              <button class="btn btn--white btn--small">Dato <i class="icon--breadcrumbs-arrow"></i>Kanal</button>
+            </div>
+          </div>
+        </header>
+        <!--Table example-->
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Dato</th>
+              <th>Program</th>
+              <th>Avvik</th>
+              <th>Fra</th>
+              <th>Til</th>
+              <th>InnslagsID</th>
+              <th class="table__head--large">HovedArtist</th>
+              <th>RecordingName</th>
+            </tr>
+          </thead>
+          <tbody class="broadcaster">
+            <tr><td><h3 class="broadcaster__title">P3</h3></td></tr>
+          </tbody>
+          <tbody>
+            <tr>
+
+              <td data-label="Dato">28.11.2015</td>
+              <td data-label="Program">Tidenes Sommer</td>
+              <td data-label="Fra">11:00</td>
+              <td data-label="Til">12:00</td>
+              <td data-label="Avvik">For mye musikk: <span>Over 100% Musikk</span></td>
+              <td data-label="InnslagsID">NONRO310402CS0003</td>
+              <td data-label="HovedArtist">David Bowie</td>
+              <td data-label="RecordingName">Blackstar</td>
+            </tr>
+            <tr>
+
+              <td data-label="Dato">28.11.2015</td>
+              <td data-label="Program">Tidenes Sommer</td>
+              <td data-label="Fra">11:00</td>
+              <td data-label="Til">12:00</td>
+              <td data-label="Avvik">For mye musikk: <span>Over 100% Musikk</span></td>
+              <td data-label="InnslagsID">NONRO310402CS0003</td>
+              <td data-label="HovedArtist">David Bowie</td>
+              <td data-label="RecordingName">Vi Lever</td>
+            </tr>
+            <tr>
+
+              <td data-label="Dato">28.11.2015</td>
+              <td data-label="Program">Tidenes Sommer</td>
+              <td data-label="Fra">11:00</td>
+              <td data-label="Til">12:00</td>
+              <td data-label="Avikk">Multirapportert: <span>2 innslager</span></td>
+              <td data-label="InnslagsID">NONRO310402CS0003</td>
+              <td data-label="HovedArtist">Tim Warfield + Kevin Hays + Greg Williams + Rodney Green + Antoine Drye </td>
+              <td data-label="RecordingName">Vi Lever</td>
+            </tr>
+          </tbody>
+          <tbody class="broadcaster">
+            <tr><td><h3 class="broadcaster__title">MP3</h3></td></tr>
+          </tbody>
+          <tbody>
+            <tr class="table__row--new">
+
+              <td data-label="Dato">28.11.2015</td>
+              <td data-label="Program">Tidenes Sommer</td>
+              <td data-label="Fra">11:00</td>
+              <td data-label="Til">12:00</td>
+              <td data-label="Avvik">For mye musikk: <span>Over 100% Musikk</span></td>
+              <td data-label="InnslagsID">NONRO310402CS0003</td>
+              <td data-label="HovedArtist">David Bowie</td>
+              <td data-label="RecordingName">NRK P3 Jingle Paackage 2013</td>
+            </tr>
+            <tr>
+
+              <td data-label="Dato">28.11.2015</td>
+              <td data-label="Program">Tidenes Sommer</td>
+              <td data-label="Fra">11:00</td>
+              <td data-label="Til">12:00</td>
+              <td data-label="Avvik">For mye musikk: <span>Over 100% Musikk</span></td>
+              <td data-label="InnslagsID">NONRO310402CS0003</td>
+              <td data-label="HovedArtist">David Bowie</td>
+              <td data-label="RecordingName">Vi Lever</td>
+            </tr>
+            <tr>
+
+              <td data-label="Dato">28.11.2015</td>
+              <td data-label="Program">Tidenes Sommer</td>
+              <td data-label="Fra">11:00</td>
+              <td data-label="Til">12:00</td>
+              <td data-label="Avvik">Multirapportert: <span>2 innslager</span></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+    </main>
+  </div><!--End site-wrapper-->
+
+<script src="js/vendor/jquery-1.11.3.min.js"></script>
+<script src="js/default.js"></script>
+
+</body>
+</html>

--- a/dist/style.css
+++ b/dist/style.css
@@ -1163,6 +1163,7 @@ input-placeholder{
 .site-header nav{
   -webkit-align-items:center;
   -ms-flex-align:center;
+  -ms-grid-row-align:center;
   align-items:center;
 }
 
@@ -1547,6 +1548,11 @@ input-placeholder{
   display:block;
   width:100%;
   margin-bottom:1rem;
+}
+.btn[disabled]{
+  background-color:#dadada;
+  border-color:rgb(123, 123, 123);
+  color:#919191;
 }
 .btn-group{
   text-align:center;
@@ -2059,6 +2065,7 @@ input-placeholder{
 .content-header__above{
   -webkit-align-items:flex-end;
   -ms-flex-align:end;
+  -ms-grid-row-align:flex-end;
   align-items:flex-end;
 }
 @media (min-width: 768px){
@@ -2084,6 +2091,7 @@ input-placeholder{
 .content-header__below{
   -webkit-align-items:center;
   -ms-flex-align:center;
+  -ms-grid-row-align:center;
   align-items:center;
   padding-bottom:0.5rem;
 }

--- a/src/css/base/_variables.css
+++ b/src/css/base/_variables.css
@@ -14,6 +14,9 @@
 --gramo-red:                                     #ed6b6a;
 --gramo-purple:                                  #a41681;
 
+--disabled-gray:                                 #dadada;
+--disabled-dark-gray:                            #919191;
+
 --slate-gray:                                    #504f56;
 --ui-gray:                                       #434D5A;
 --off-gray:                                      #a5a4ab;

--- a/src/css/blocks/_button.css
+++ b/src/css/blocks/_button.css
@@ -106,4 +106,10 @@
     width: 100%;
     margin-bottom: 1rem;
   }
+
+  &[disabled] {
+    background-color: var(--disabled-gray);
+    border-color: color(var(--disabled-dark-gray) shade(15%));
+    color: var(--disabled-dark-gray);
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -291,6 +291,13 @@
         <button class="btn btn--primary btn--small btn--danger">Small button danger</button>
         <button class="btn btn--small btn--info">Small button info</button>
         <button class="btn btn--small btn--success">Small button success</button>
+        <h3>Disabled</h3>
+        <button disabled="disabled" class="btn btn--primary btn--large">Large button</button>
+        <button disabled="disabled" class="btn btn--primary">Medium button</button>
+        <button disabled="disabled" class="btn btn--primary btn--small">Small button primary</button>
+        <button disabled="disabled" class="btn btn--primary btn--small btn--danger">Small button danger</button>
+        <button disabled="disabled" class="btn btn--small btn--info">Small button info</button>
+        <button disabled="disabled" class="btn btn--small btn--success">Small button success</button>
       </section>
       <hr class="horizontal-rule">
       <!--End Button examples-->

--- a/src/style.css
+++ b/src/style.css
@@ -1163,6 +1163,7 @@ input-placeholder{
 .site-header nav{
   -webkit-align-items:center;
   -ms-flex-align:center;
+  -ms-grid-row-align:center;
   align-items:center;
 }
 
@@ -1547,6 +1548,11 @@ input-placeholder{
   display:block;
   width:100%;
   margin-bottom:1rem;
+}
+.btn[disabled]{
+  background-color:#dadada;
+  border-color:rgb(123, 123, 123);
+  color:#919191;
 }
 .btn-group{
   text-align:center;
@@ -2059,6 +2065,7 @@ input-placeholder{
 .content-header__above{
   -webkit-align-items:flex-end;
   -ms-flex-align:end;
+  -ms-grid-row-align:flex-end;
   align-items:flex-end;
 }
 @media (min-width: 768px){
@@ -2084,6 +2091,7 @@ input-placeholder{
 .content-header__below{
   -webkit-align-items:center;
   -ms-flex-align:center;
+  -ms-grid-row-align:center;
   align-items:center;
   padding-bottom:0.5rem;
 }


### PR DESCRIPTION
Når elementer har `disabled` satt har vi i dag at musa har cursor i steden for pointer. Se følgende bilde, hvor første lagre knapp er deaktivert.
![image](https://cloud.githubusercontent.com/assets/92300/12377858/fd17e9a4-bd2b-11e5-89cf-6dfeb03c6681.png)

Med denne pull requesten ser det slik ut:
![image](https://cloud.githubusercontent.com/assets/92300/12378047/1e1a8a48-bd32-11e5-8d5a-44bb44de433c.png)
