### PR TITLE
Scrollable areas are not constricted when printing

### DIFF
--- a/dist/minside.css
+++ b/dist/minside.css
@@ -1218,6 +1218,10 @@ table{
     text-align:right;
   }
 
+.scrollable-area{
+  height:auto!important;
+}
+
 [class*=--screen]{
   display:none!important;
 }

--- a/dist/style.css
+++ b/dist/style.css
@@ -1218,6 +1218,10 @@ table{
     text-align:right;
   }
 
+.scrollable-area{
+  height:auto!important;
+}
+
 [class*=--screen]{
   display:none!important;
 }

--- a/src/css/base/_print.css
+++ b/src/css/base/_print.css
@@ -67,6 +67,10 @@ table {
   }
 }
 
+.scrollable-area {
+  height: auto!important;
+}
+
 [class*=--screen] {
   display: none!important;
 }

--- a/src/minside.css
+++ b/src/minside.css
@@ -1218,6 +1218,10 @@ table{
     text-align:right;
   }
 
+.scrollable-area{
+  height:auto!important;
+}
+
 [class*=--screen]{
   display:none!important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1218,6 +1218,10 @@ table{
     text-align:right;
   }
 
+.scrollable-area{
+  height:auto!important;
+}
+
 [class*=--screen]{
   display:none!important;
 }


### PR DESCRIPTION
Scrollable areas are constructed to fit the height of the screen. This is however not desired when printing, as it would hide content and print a scroll bar.