### PR TITLE
fix hidden attribute in min side

### DIFF
--- a/dist/minside.css
+++ b/dist/minside.css
@@ -25,7 +25,7 @@ audio:not([controls]){
 }
 
 [hidden], template{
-  display:none;
+  display:none!important;
 }
 
 a{

--- a/dist/style.css
+++ b/dist/style.css
@@ -25,7 +25,7 @@ audio:not([controls]){
 }
 
 [hidden], template{
-  display:none;
+  display:none!important;
 }
 
 a{

--- a/src/css/base/_normalize.css
+++ b/src/css/base/_normalize.css
@@ -77,7 +77,7 @@ audio:not([controls]) {
 
 [hidden],
 template {
-  display: none;
+  display: none!important;
 }
 
 /* Links

--- a/src/minside.css
+++ b/src/minside.css
@@ -25,7 +25,7 @@ audio:not([controls]){
 }
 
 [hidden], template{
-  display:none;
+  display:none!important;
 }
 
 a{

--- a/src/style.css
+++ b/src/style.css
@@ -25,7 +25,7 @@ audio:not([controls]){
 }
 
 [hidden], template{
-  display:none;
+  display:none!important;
 }
 
 a{


### PR DESCRIPTION
the hidden atrtibute was not working properly in min-side.
Added !important in hidden style in _normalize.css to override other styles.

problem is described here: https://www.w3.org/TR/html5/editing.html#the-hidden-attribute

> NOTE: 
>
> Because this attribute is typically implemented using CSS, it’s also possible to override it using CSS. For instance, a rule that applies 'display: block' to all elements will cancel the effects of the hidden attribute. Authors therefore have to take care when writing their style sheets to make sure that the attribute is still styled as expected.

Basically I think this problem arises due to the use of !important on other, less specific, `display:` styles.