### PR TITLE
Change the background colour of the horizontal rule text on login page

### DIFF
--- a/dist/minside.css
+++ b/dist/minside.css
@@ -3303,7 +3303,7 @@ hr.horizontal-rule--choice:after{
   top:-1.5rem;
   font-size:1.8rem;
   color:#a5a4ab;
-  background:#f9f9f9;
+  background:#fdfdfd;
   padding:0 0.75rem;
   font-style:italic;
 }

--- a/src/css/minside/_atoms/_horizontal-rule.css
+++ b/src/css/minside/_atoms/_horizontal-rule.css
@@ -16,7 +16,7 @@ hr, .horizontal-rule {
   text-align: center;
   margin: 2rem 0;
   background: var(--silver);
-  
+
   hr {
     height: 1px;
     border: 0;
@@ -77,7 +77,7 @@ hr.horizontal-rule--choice {
     top: -1.5rem;
     font-size: 1.8rem;
     color: var(--off-gray);
-    background: var(--x-light-gray);
+    background: var(--gramo-white);
     padding: 0 0.75rem;
     font-style: italic;
   }

--- a/src/minside.css
+++ b/src/minside.css
@@ -3303,7 +3303,7 @@ hr.horizontal-rule--choice:after{
   top:-1.5rem;
   font-size:1.8rem;
   color:#a5a4ab;
-  background:#f9f9f9;
+  background:#fdfdfd;
   padding:0 0.75rem;
   font-style:italic;
 }


### PR DESCRIPTION
It would be nice to inherit the colour from the grandparent, however that is not
possible in pure CSS. Since this is only used on the login page, this will have
to do for now.