### PR TITLE
Change the color of links to dark gray

### DIFF
--- a/src/css/minside/base/_base.css
+++ b/src/css/minside/base/_base.css
@@ -41,9 +41,9 @@ body {
   }}
 
 a {
-  color: var(--gramo-sea-green);
+  color: var(--dark-gray);
   cursor: pointer;
-  
+
   &:active,
   &:hover {
     outline: 0;
@@ -59,7 +59,7 @@ h1 {
 h2 {
   font-size: var(--h2-font-size);
   margin: 0;
-  
+
   &.text--thin {
     font-size: var(--h1-font-size);
     margin: 0;
@@ -114,7 +114,7 @@ h4 {
 
 p {
   margin: 0;
-  
+
   &.with-margin {
     @extend %margin-bottom;
   }


### PR DESCRIPTION
From gramo-org/min-side#1743

> Please make sure all links on Min Side are changed to "dark-grey" color for consistency (as this will be used in the search)